### PR TITLE
每個任務（副本）有發送邀請人數限制

### DIFF
--- a/app/controllers/instances_controller.rb
+++ b/app/controllers/instances_controller.rb
@@ -18,6 +18,9 @@ class InstancesController < ApplicationController
       # @instance.inviting_users 是正在邀請的使用者
       #所有邀情函
       @invitations = @instance.inviting_invitations.includes(:user)
+      #剩下可發送的邀請函數量
+      @remaining_invitations_count = @instance.remaining_invitations_count
+
     end
   end
 

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -3,15 +3,20 @@ class InvitationsController < ApplicationController
   before_action :set_invitation
 
   def show
-  #要驗證只有受邀請的人可以進這個action
-
     @inviter = @invitation.user                    #邀請者
     @invitee = @invitation.invitee                 #受邀者
-    @mission = @invitation.instance.mission
-    @invite_msgs = @invitation.invite_msgs.includes(:user)
-    if @invitation.state == 'inviting'
-      @invite_msg = InviteMsg.new
+    if current_user == @inviter || current_user == @invitee
+      #只有邀請者或受邀者才可以瀏覽
+      @mission = @invitation.instance.mission
+      @invite_msgs = @invitation.invite_msgs.includes(:user)
+      if @invitation.state == 'inviting'
+        @invite_msg = InviteMsg.new
+      end
+    else
+      flash[:alert] = '::Invitation: 禁止瀏覽！'
+      redirect_back(fallback_location: root_path)
     end
+
   end
 
   def accept
@@ -69,5 +74,6 @@ class InvitationsController < ApplicationController
   def set_invitation
     @invitation = Invitation.find(params[:id])
   end
+
 
 end

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -1,7 +1,7 @@
 class InvitationsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_invitation
-  before_action :auth_invitee, only: [:accpet, :decline]
+  before_action :auth_invitee, only: [:accept, :decline]
   before_action :check_inviting, only: [:accept, :decline, :cancel]
 
   def show
@@ -24,7 +24,7 @@ class InvitationsController < ApplicationController
   def accept
     #受邀者可以接受邀請
     #before_aciton :auth_invitee
-    #cbefore_aciton :heck_inviting
+    #before_aciton :check_inviting
     # binding.pry
     @invitation.state = 'accept'
     @invitation.save

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -1,9 +1,10 @@
 class InvitationsController < ApplicationController
   before_action :authenticate_user!
+  before_action :set_invitation
 
   def show
   #要驗證只有受邀請的人可以進這個action
-    @invitation = Invitation.find(params[:id])
+
     @inviter = @invitation.user                    #邀請者
     @invitee = @invitation.invitee                 #受邀者
     @mission = @invitation.instance.mission
@@ -18,8 +19,6 @@ class InvitationsController < ApplicationController
     # 1.是不是本人
     # 2.該副本是否已經啟動
     # binding.pry
-
-    @invitation = Invitation.find(params[:id])
     if @invitation.invitee == current_user && @invitation.instance.state == 'teaming' && @invitation.state == 'inviting'
       @invitation.state = 'accept'
       @invitation.save
@@ -41,7 +40,6 @@ class InvitationsController < ApplicationController
     #要先做檢覈
     # 1.是不是本人
     # 2.invitation 狀態是 inviting
-    @invitation = Invitation.find(params[:id])
     if current_user == @invitation.invitee && @invitation.state == 'inviting'
       @invitation.state = 'decline'
       @invitation.save
@@ -56,9 +54,7 @@ class InvitationsController < ApplicationController
   def cancel
     #邀請者可以取消邀請
     #invitatoin.state = 'cancel'
-    @invitation = Invitation.find(params[:id])
     #只有發起這個邀請的人可以取消邀請
-
     if current_user == @invitation.user && @invitation.state == "inviting"
       @invitation.update!(state: "cancel")
       flash[:notice] = "取消邀請"
@@ -67,6 +63,11 @@ class InvitationsController < ApplicationController
       flash[:alert] = "操作失敗"
       redirect_back(fallback_location: root_path)
     end
+  end
+
+  private
+  def set_invitation
+    @invitation = Invitation.find(params[:id])
   end
 
 end

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -1,6 +1,8 @@
 class InvitationsController < ApplicationController
   before_action :authenticate_user!
   before_action :set_invitation
+  before_action :auth_invitee, only: [:accpet, :decline]
+  before_action :check_inviting, only: [:accept, :decline, :cancel]
 
   def show
     @inviter = @invitation.user                    #邀請者
@@ -20,47 +22,33 @@ class InvitationsController < ApplicationController
   end
 
   def accept
-    #要先做檢覈
-    # 1.是不是本人
-    # 2.該副本是否已經啟動
+    #受邀者可以接受邀請
+    #before_aciton :auth_invitee
+    #cbefore_aciton :heck_inviting
     # binding.pry
-    if @invitation.invitee == current_user && @invitation.instance.state == 'teaming' && @invitation.state == 'inviting'
-      @invitation.state = 'accept'
-      @invitation.save
-      # binding.pry
-      flash[:notice] = '接受任務'
-      redirect_to instance_path(@invitation.instance)
-    elsif @invitation.instance.state == 'in_progress'
-      flash[:alert] = '已經有別人搶先一步，接受邀請失敗'
-      redirect_back(fallback_location: root_path)
-    else
-      flash[:alert] = '無法接受任務邀請'
-      redirect_back(fallback_location: root_path)
-    end
-
+    @invitation.state = 'accept'
+    @invitation.save
+    # binding.pry
+    flash[:notice] = '接受任務'
+    redirect_to instance_path(@invitation.instance)
   end
 
   def decline
     # 受邀者可以拒絕邀請
-    #要先做檢覈
-    # 1.是不是本人
-    # 2.invitation 狀態是 inviting
-    if current_user == @invitation.invitee && @invitation.state == 'inviting'
-      @invitation.state = 'decline'
-      @invitation.save
-      flash[:notice] = '拒絕邀請'
-      redirect_back(fallback_location: root_path)
-    else
-      flash[:alert] = '::decline: 存取失敗'
-      redirect_back(fallback_location: root_path)
-    end
+    #before_aciton :auth_invitee
+    #before_aciton :check_inviting
+    @invitation.state = 'decline'
+    @invitation.save
+    flash[:notice] = '拒絕邀請'
+    redirect_back(fallback_location: root_path)
   end
 
   def cancel
     #邀請者可以取消邀請
-    #invitatoin.state = 'cancel'
+    #before_aciton :check_inviting
+
     #只有發起這個邀請的人可以取消邀請
-    if current_user == @invitation.user && @invitation.state == "inviting"
+    if current_user == @invitation.user
       @invitation.update!(state: "cancel")
       flash[:notice] = "取消邀請"
       redirect_to instance_path(@invitation.instance)
@@ -75,5 +63,20 @@ class InvitationsController < ApplicationController
     @invitation = Invitation.find(params[:id])
   end
 
+  def auth_invitee
+    #確認current_user是受邀者
+    if current_user != @invitation.invitee
+      flash[:alert] = '::invitation: 操作禁止'
+      redirect_back(fallback_location: root_path)
+    end
+  end
+
+  def check_inviting
+    # 檢查邀請函狀態以及組隊狀態
+    if @invitation.state != 'inviting' || @invitation.instance.state != 'teaming'
+      flash[:alert] = 'Sorry，任務進行中或是邀請函失效！'
+      redirect_back(fallback_location: root_path)
+    end
+  end
 
 end

--- a/app/models/instance.rb
+++ b/app/models/instance.rb
@@ -49,14 +49,17 @@ class Instance < ApplicationRecord
   # ::instance method:: 確認user可被邀請？
   def can_invite?(user)
     # ----說明----
+    # 確認是否還有足夠的邀請函可以發送
     # 確認user為可接受邀本任務
     # 確認user不是 邀請中的使用者
     # 確認user不是member
     # ------------
     # 如果user可以接受任務
-    if user.take_mission?(self.mission)
+    if self.remaining_invitations_count <= 0
+      #如果沒有邀請函可以發送，則不能邀請該user
+      return false
+    elsif user.take_mission?(self.mission)
       # user不在 邀請函是inviting 的集合中 且不是member, 就是可發送邀請
-     
       return ( !self.invitees.where('invitations.state = ?','inviting').include?(user) ) &&  ( !self.members.include?(user) )
     else
       return false

--- a/app/models/instance.rb
+++ b/app/models/instance.rb
@@ -81,6 +81,10 @@ class Instance < ApplicationRecord
   def inviting_invitations
     self.invitations.where('state = ?', 'inviting')
   end
+  # ::instance method:: 是否還有邀請函可以發送
+  def remaining_invitations_count
+    self.mission.invitation_number - self.inviting_invitations.count
+  end
 
   private
   # ::instance method:: 自動設定任務副本instance狀態

--- a/app/views/instances/_teaming.html.erb
+++ b/app/views/instances/_teaming.html.erb
@@ -15,12 +15,25 @@
 
 <div class="row mb-4">
   <div class="col-12">
-    <h3>可選隊員</h3>
+    <h3>可選隊員 </h3>
+    <h5><span class="badge badge-info">你還可發送<%=@remaining_invitations_count%> 張邀請</span></h5>
   </div>
-  <% @candidates.each do |user| %>
-    <div class="col-md-3 my-3">
-      <%= render partial:"shared/user_card" , locals: {user: user} %>
-      <%= button_to "邀請" , invite_user_path(user), params: {instance_id: @instance.id}, class: "btn btn-primary" %>
-    </div>
+  
+  <% if @remaining_invitations_count > 0 %>
+    <!-- 還有剩下的邀請函 -->
+    <% @candidates.each do |user| %>
+      <div class="col-md-3 my-3">
+        <%= render partial:"shared/user_card" , locals: {user: user} %>
+        <%= button_to "邀請" , invite_user_path(user), params: {instance_id: @instance.id}, class: "btn btn-primary" %>
+      </div>
+    <% end %>
+  <% else %>
+    <!-- 沒有剩下的邀請函 -->
+    <% @candidates.each do |user| %>
+      <div class="col-md-3 my-3">
+        <%= render partial:"shared/user_card" , locals: {user: user} %>
+        <div class="btn btn-primary disabled">邀請</div>
+      </div>
+    <% end %>
   <% end %>
 </div>


### PR DESCRIPTION
# Why?
- 限制發送邀請函的數量

# What?
- 修改instance.rb
  - 新增 method `remaining_invitations_count` : 可以計算目前有效的邀請函數量
  - 修改 method `can_invite?` : 加上限制條件，如果沒有足夠的邀請函，不能邀請使用者

- 修改` instance#show`:  邀請函剩餘數及無剩餘邀請函的判斷
![2018-03-17 11 23 12](https://user-images.githubusercontent.com/15953545/37551171-a2859306-29d5-11e8-8c56-e01db6393ff9.png)
cc @Cronobow  @eggyy1224 

