### PR TITLE
取消副本任務，會取消邀請函

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -274,7 +274,7 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
-    loofah (2.2.0)
+    loofah (2.2.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     lumberjack (1.0.12)

--- a/app/controllers/instances_controller.rb
+++ b/app/controllers/instances_controller.rb
@@ -1,7 +1,7 @@
 class InstancesController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_instance, only: [:show, :submit, :abort, :review]
-  before_action :authenticate_instance_member, only: [:show, :submit, :abort, :review]
+  before_action :set_instance, only: [:show, :submit, :abort, :review, :cancel]
+  before_action :authenticate_instance_member, only: [:show, :submit, :abort, :review, :cancel]
 
   def index
     @instances_in_progress = current_user.instances.where(state: 'in_progress')
@@ -80,11 +80,25 @@ class InstancesController < ApplicationController
     end
   end
 
+  def cancel
+    #取消組隊
+    #取消後，其他邀請函會自動取消
+    if @instance.state == 'teaming'
+      flash[:notice] = '放棄組隊！'
+      @instance.cancel!
+      redirect_to instance_path(@instance)
+    else
+      flash[:alert] = "存取禁止"
+      redirect_back(fallback_location: root_path)
+    end
+
+  end
+
   def abort
   # 放棄任務
     #使用者可以直接中止任務
-    if @instance.state == "teaming" || @instance.state == "in_progress"
-      #確認副本是 teaming 和 in_progress
+    if @instance.state == 'in_progress'
+      #確認副本是in_progress
       @instance.abort!
       flash[:notice] = "任務中止"
       # 回到instance#show

--- a/app/helpers/instances_helper.rb
+++ b/app/helpers/instances_helper.rb
@@ -1,11 +1,16 @@
 module InstancesHelper
   def abort_button(instance)
     if instance.present?
-      case instance.state
-        when "in_progress"
-          link_to('放棄任務', abort_instance_path, method: :post, class: "btn btn-danger btn-sm", data: { confirm: "跟隊友溝通過了嗎，確定要放棄任務？" })
-        when "teaming"
-          link_to('放棄組隊', abort_instance_path, method: :post, class: "btn btn-danger btn-sm", data: { confirm: "放棄組隊後，所有邀請函皆會失效。\n\n確定要放棄組隊？" })
+      if instance.state == 'in_progress'
+        link_to('放棄任務', abort_instance_path, method: :post, class: "btn btn-danger btn-sm", data: { confirm: "跟隊友溝通過了嗎，確定要放棄任務？" })
+      end
+    end
+  end
+
+  def cancel_button(instance)
+    if instance.present?
+      if instance.state == 'teaming'
+        link_to('放棄組隊', cancel_instance_path, method: :post, class: "btn btn-danger btn-sm", data: { confirm: "放棄組隊後，所有邀請函皆會失效。\n\n確定要放棄組隊？" })
       end
     end
   end
@@ -15,6 +20,7 @@ module InstancesHelper
     when 'teaming' then '隊友招募中'
     when 'in_progress' then '副本進行中'
     when 'complete' then '副本已完成'
+    when 'cancel' then '放棄組隊'
     when 'abort' then '副本已放棄'
     end
   end

--- a/app/models/instance.rb
+++ b/app/models/instance.rb
@@ -41,9 +41,23 @@ class Instance < ApplicationRecord
     end
   end
 
+  def cancel!
+    if self.state == 'teaming'
+      self.state = 'cancel'
+      self.save
+
+      #取消所有人的邀請函
+      self.invitations.find_inviting.each do |invitation|
+        invitation.cancel!
+        invitation.send_cancel_msg('我已經取消了本次任務組隊！-- 系統訊息')
+      end
+    end
+  end
+
+
   # ::instance method::  任務副本instance終止
   def abort!
-    if self.state == 'in_progress' || self.state == 'teaming'
+    if self.state == 'in_progress'
       self.state = 'abort'
       self.save
 
@@ -59,6 +73,7 @@ class Instance < ApplicationRecord
       end
     end
   end
+
 
   # ::instance method:: 確認user為instance的成員
   def is_member?(user)

--- a/app/models/instance.rb
+++ b/app/models/instance.rb
@@ -117,9 +117,16 @@ class Instance < ApplicationRecord
     #如果設定在after_commit 會造成查詢次數過多
     #這裡要想一下怎麼改會比較好
     if self.state == 'teaming'
+    # 如果是人數已經滿了，則副本開始
       if self.members.length == self.mission.participant_number
         self.state = 'in_progress'
         self.save
+        # 副本開始，其他邀請函取消
+        # invitation.cancel inviting
+        self.invitations.find_inviting.each do |invitation|
+          invitation.cancel!
+          invitation.send_cancel_msg('已經有其他人答應我的組隊邀請！-- 系統訊息')
+        end
       end
     end
   end

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -6,6 +6,10 @@ class Invitation < ApplicationRecord
   #可能要加counter cache
   has_many :invite_msgs
 
+  scope :find_inviting, -> {
+    where(state: 'inviting')
+  }
+
   def time_updated!
     self.updated_at = Time.now
     self.save
@@ -23,10 +27,25 @@ class Invitation < ApplicationRecord
     invite_msg.save
   end
 
-  def send_cancel_msg
+  def send_cancel_msg(*options)
+    if(options)
+      options.each do |option|
+        invite_msg = self.invite_msgs.create(content: option)
+        invite_msg.user = self.user
+        invite_msg.save
+      end
+    end
+
     invite_msg = self.invite_msgs.create(content: "很抱歉，我已取消這次邀請，有緣再見 -- 系統訊息")
     invite_msg.user = self.user
     invite_msg.save
+  end
+
+  def cancel!
+    if self.state == 'inviting'
+      self.state = 'cancel'
+      self.save
+    end
   end
 
   private

--- a/app/views/instances/show.html.erb
+++ b/app/views/instances/show.html.erb
@@ -6,7 +6,7 @@
       <div class="container">
         <div class="row mb-4">
           <div class="col">
-            <h2><%= instance_title(@instance) %> <span class="ml-3"><%= abort_button(@instance) %></span></h2>
+            <h2><%= instance_title(@instance) %> <span class="ml-3"><%= abort_button(@instance) %><%= cancel_button(@instance) %></span></h2>
           </div>
         </div>
         <%= render partial:'mission_info', locals: {mission: @mission} %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,8 @@ Rails.application.routes.draw do
     member do
       post :submit
       #任務完成，提交答案
+      post :cancel
+      #取消組隊
       post :abort
       #放棄任務
     end


### PR DESCRIPTION
# Why 
- 取消組隊，放棄任務，完成組隊，會取消邀其他邀請函
- 之前沒有做到取消組隊(instance.state == cancel)的狀態，已補上
<img width="795" alt="2018-03-22 2 10 16" src="https://user-images.githubusercontent.com/15953545/37754247-aeac08fe-2ddb-11e8-9644-53fe6d4a0d98.png">

# What
- 增加instance#cancel action , route, view, helper
- 可以自動發送訊息，有修改 @Cronobow 之前寫的cancel msg, 可以包參數進去（多送幾句話）

cc @Cronobow  @eggyy1224 

