### PR TITLE
增加XP值

### DIFF
--- a/app/controllers/missions_controller.rb
+++ b/app/controllers/missions_controller.rb
@@ -34,6 +34,10 @@ class MissionsController < ApplicationController
       #產生一個新副本
       instance = current_user.instances.create(mission_id: params[:id])
 
+      instance.xp = mission.xp
+      #設定副本xp值
+      #如果有特殊xp加乘 可以在這邊修改
+
       #current_user.save!
       instance.save!
       flash[:notice] = "挑戰任務成功"

--- a/app/models/instance.rb
+++ b/app/models/instance.rb
@@ -31,7 +31,7 @@ class Instance < ApplicationRecord
       self.save
       # binding.pry
       # 產生所有隊員的reivew
-      self.members.each do |reviewee| 
+      self.members.each do |reviewee|
         self.members.each do |reviewer|
           if reviewee != reviewer
             new_review = reviewee.reviews.build(instance_id: self.id)
@@ -40,6 +40,13 @@ class Instance < ApplicationRecord
           end
         end
       end
+
+      self.members.each do |member|
+        member.add_xp(self.xp)
+        puts "member #{member.name} add xp #{self.xp}"
+        member.save
+      end
+
 
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -114,6 +114,11 @@ class User < ApplicationRecord
     ]
   end
 
+  def add_xp(xp)
+    self.xp += xp
+    self.level = self.xp / 1000
+    self.save!
+  end
 
   def admin?
     self.role == 'admin'

--- a/app/views/instances/_mission_info.html.erb
+++ b/app/views/instances/_mission_info.html.erb
@@ -11,7 +11,7 @@
         <div class="col-8 pl-0">
           <div class="card-body">
             <h5 class="card-title"><%= mission.name %></h5>
-            <p class="card-text"><span class="badge badge-success">Level <%= mission.level %></span> <span class="badge badge-success">Team# <%= mission.participant_number %></span></p>
+            <p class="card-text"><span class="badge badge-success">Level <%= mission.level %></span> <span class="badge badge-success">Team# <%= mission.participant_number %></span> <span class="badge badge-info">XP+ <%= instance.xp %></span></p>
             <p class="card-text"><%= mission.description %></p>
           </div>
         </div>

--- a/app/views/instances/show.html.erb
+++ b/app/views/instances/show.html.erb
@@ -9,7 +9,7 @@
             <h2><%= instance_title(@instance) %> <span class="ml-3"><%= abort_button(@instance) %><%= cancel_button(@instance) %></span></h2>
           </div>
         </div>
-        <%= render partial:'mission_info', locals: {mission: @mission} %>
+        <%= render partial:'mission_info', locals: {mission: @mission, instance: @instance} %>
 
         <% case @instance.state %>
           <% when "teaming" %>

--- a/app/views/missions/_show_mission.html.erb
+++ b/app/views/missions/_show_mission.html.erb
@@ -17,6 +17,7 @@
               <li>任務名稱: <%=@mission.name%></li>
               <li>等級: <%= @mission.level%></li>
               <li>參加人數：<%= @mission.participant_number %></li>
+              <li>XP經驗值獎勵：<%= @mission.xp %>點</li>
               <li>任務內容：<%= simple_format @mission.description %></li>
             </ul>
           </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -15,6 +15,7 @@
             <p>自我介紹 <%= @user.description %></p>
             <p>性別 <%= @user.gender %></p>
             <p>等級 <%= @user.level %></p>
+            <p>XP值 <%= @user.xp %></p>
             <p>角色 <%= @user.role %></p>
             <p>邀請信箱 <%= transcript_user_state(@user.available) %></p>
 

--- a/db/migrate/20180323060700_add_xp.rb
+++ b/db/migrate/20180323060700_add_xp.rb
@@ -1,0 +1,7 @@
+class AddXp < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :xp, :integer, default: 0, null: false
+    add_column :instances, :xp, :integer, default: 100, null: false
+    add_column :missions, :xp, :integer, default: 100, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_03_23_025749) do
+ActiveRecord::Schema.define(version: 2018_03_23_060700) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -39,6 +39,7 @@ ActiveRecord::Schema.define(version: 2018_03_23_025749) do
     t.datetime "updated_at", null: false
     t.string "answer", default: "", null: false
     t.integer "modifier_id"
+    t.integer "xp", default: 100, null: false
   end
 
   create_table "invitations", force: :cascade do |t|
@@ -67,6 +68,7 @@ ActiveRecord::Schema.define(version: 2018_03_23_025749) do
     t.string "image"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "xp", default: 100, null: false
   end
 
   create_table "reviews", force: :cascade do |t|
@@ -110,6 +112,7 @@ ActiveRecord::Schema.define(version: 2018_03_23_025749) do
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
     t.boolean "available", default: true, null: false
+    t.integer "xp", default: 0, null: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -52,4 +52,16 @@ namespace :dev do
     puts "create #{Mission.count} fake missions"
     puts "Now you have #{Mission.count} missions!"
   end
+
+  task fake_xp: :environment do
+    Mission.all.each do |mission|
+        mission.xp = Random.rand(200..600)
+        mission.save
+    end
+    User.all.each do |user|
+        user.xp = user.level * 1000
+        user.save
+    end
+    puts 'generated fake xp for missions and users!'
+  end
 end


### PR DESCRIPTION
# Why 
增加xp系統
使用者挑戰完副本，可以增加經驗值
目前是1000分一個level
超過1000會自動晉級
![2018-03-23 3 21 19](https://user-images.githubusercontent.com/15953545/37816403-e29861d0-2ead-11e8-8990-10c8e96744a3.png)
# What
- 增加 users instance mission 的xp column
- mission challenge 後 instance會複製xp (這是為了以後instance可能會有特別的xp加成)
- user.xp_add 可以加xp, 自動計算有沒有level up
-  增加fake_xp rake


cc @Cronobow  @eggyy1224   請記得rails db:migrate

