### PR TITLE
將通知修改為更進階的功能

### DIFF
--- a/app/assets/javascripts/notification.js
+++ b/app/assets/javascripts/notification.js
@@ -6,14 +6,16 @@
 class Notifications {
   constructor() {
     this.handleClick = this.handleClick.bind(this);
+    this.unreadClick = this.unreadClick.bind(this);
     this.handleSuccess = this.handleSuccess.bind(this);
+    this.readAll = this.readAll.bind(this);
     this.notifications = $("[data-behavior='notifications']");
 
     if (this.notifications.length > 0) {
       this.handleSuccess(this.notifications.data("notifications"));
       
       $("[data-behavior='notifications-link']").on("click", this.handleClick);
-
+      
       this.getNewNotifications();
       // setInterval((() => {
       //   console.log("getNotifications!!");
@@ -35,12 +37,37 @@ class Notifications {
 
   handleClick(e) {
     console.log('handleClick');
-    return $.ajax({
-      url: "/notifications/mark_as_read",
+    $.ajax({
+      url: "/notifications/mark_as_checked_all",
       dataType: "JSON",
       method: "POST",
       success() {
-        $("[data-behavior='unread-count']").hide();
+        $("[data-behavior='unchecked-count']").hide();
+      }
+    });
+  }
+
+  unreadClick(e){
+    let id = e.delegateTarget.id;
+    let href = e.delegateTarget.href;
+    console.log(e.delegateTarget.id);
+    e.preventDefault();
+    $.ajax({
+      url: "/notifications/"+id+"/mark_as_read",
+      dataType: "JSON",
+      method: "POST",
+      success() {
+        window.location.href = href;
+      }
+    });
+  }
+  readAll(e){
+    $.ajax({
+      url: "/notifications/mark_as_read_all",
+      dataType: "JSON",
+      method: "POST",
+      success() {
+        $(".list-group-item").removeClass("unread-notification");
       }
     });
   }
@@ -48,17 +75,19 @@ class Notifications {
   handleSuccess(data) {
     const items = $.map(data, notification => notification.template);
     console.log(items);
-    let unread_count = 0;
+    let unchecked_count = 0;
     $.each(data, function(i, notification) {
-      if (notification.unread) {
-        return unread_count += 1;
+      if (notification.unchecked) {
+        return unchecked_count += 1;
       }
     });
-    console.log(unread_count)
-    unread_count === 0 ? $("[data-behavior='unread-count']").hide() : $("[data-behavior='unread-count']").show()
-    $("[data-behavior='unread-count']").text(unread_count);
-    $("[data-behavior='notification-items']").html(items);
+    console.log(unchecked_count)
+    unchecked_count === 0 ? $("[data-behavior='unchecked-count']").hide() : $("[data-behavior='unchecked-count']").show()
+    $("[data-behavior='unchecked-count']").text(unchecked_count);
     $("[data-behavior='notification-items'] > .notification-head").after(items);
+    $(".unread-notification a").on("click",this.unreadClick);
+    $("[data-behavior='notification-readall']").on("click",this.readAll);
+
   }
 }
 

--- a/app/assets/javascripts/notification.js
+++ b/app/assets/javascripts/notification.js
@@ -58,6 +58,7 @@ class Notifications {
     unread_count === 0 ? $("[data-behavior='unread-count']").hide() : $("[data-behavior='unread-count']").show()
     $("[data-behavior='unread-count']").text(unread_count);
     $("[data-behavior='notification-items']").html(items);
+    $("[data-behavior='notification-items'] > .notification-head").after(items);
   }
 }
 

--- a/app/assets/stylesheets/style.scss
+++ b/app/assets/stylesheets/style.scss
@@ -26,3 +26,7 @@
 .uk-notify {
   z-index: 1060;
 }
+
+.unread-notification {
+  background-color: #FAFAFA;
+}

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -6,6 +6,17 @@ class NotificationsController < ApplicationController
   end
 
   def mark_as_read
+    @notification = Notification.find(params[:id])
+    @notification.update(read_at: Time.zone.now)
+    render json: {success: true}
+  end
+
+  def mark_as_checked_all
+    @notifications = Notification.where(recipient: current_user).unchecked
+    @notifications.update_all(checked_at: Time.zone.now)
+    render json: {success: true}
+  end
+  def mark_as_read_all
     @notifications = Notification.where(recipient: current_user).unread
     @notifications.update_all(read_at: Time.zone.now)
     render json: {success: true}

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -5,4 +5,5 @@ class Notification < ApplicationRecord
   default_scope {order('created_at DESC')}
 
   scope :unread, -> { where(read_at: nil) }
+  scope :unchecked, -> {where(checked_at: nil)}
 end

--- a/app/views/invitations/show.html.erb
+++ b/app/views/invitations/show.html.erb
@@ -1,10 +1,15 @@
-<div class="container">
-    <div>
-      <h4 class="modal-title"> <%= @inviter.name %> 邀請 <%= @invitee.name %> 進行任務 (邀請函狀態：<%= @invitation.state %>)</h4>
-      <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+<aside class="aside-container">
+  <%= render partial: "layouts/sidebar" %>
+</aside>
+<section>
+  <div class="section-container">
+    <div class="content-wrapper">
+      <div class="content-heading">
+        <h3> <%= @inviter.name %> 邀請 <%= @invitee.name %> 進行任務 (邀請函狀態：<%= @invitation.state %>)</h3>
+      </div>
     </div>
     <div>
-      <div class="container-fluid">
+      <div class="container">
         <div class="row mb-4">
           <% if @inviter != current_user  %>
             <div class="col-md-6 mb-3">
@@ -35,7 +40,7 @@
           <%end%>
         <%end%>
         <!--===============================-->
-      </div>
+
     </div>
     <% if @invitation.state == 'inviting' %>
       <div class="modal-footer">
@@ -49,7 +54,10 @@
         </div>
       </div>
     <%end%>
-</div>
+    </div>
+  </div>
+</section>
+
 
 <script>
     // 按enter可以直接送出

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -35,7 +35,7 @@
               <span class="badge badge-danger" data-behavior='unread-count'></span>
            </a>
            <!-- START Dropdown menu-->
-           <div class="dropdown-menu dropdown-menu-right animated flipInX">
+           <div class="dropdown-menu dropdown-menu-right ">
               <div class="dropdown-item" data-behavior='notification-items'>
                  <!-- START list group-->
                  <div class="list-group" >

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -32,13 +32,19 @@
         <li class="nav-item dropdown dropdown-list" data-behavior = 'notifications' >
            <a class="nav-link dropdown-toggle dropdown-toggle-nocaret" href="#" data-toggle="dropdown" data-behavior='notifications-link'>
               <em class="icon-bell"></em>
-              <span class="badge badge-danger" data-behavior='unread-count'></span>
+              <span class="badge badge-danger" data-behavior='unchecked-count'></span>
            </a>
            <!-- START Dropdown menu-->
-           <div class="dropdown-menu dropdown-menu-right ">
-              <div class="dropdown-item" data-behavior='notification-items'>
-                 <!-- START list group-->
-                 <div class="list-group" >
+           <div class="dropdown-menu dropdown-menu-right">
+              <div class="dropdown-item" >
+                <!-- START list group-->
+                <div class="list-group" data-behavior='notification-items'>
+                  <div class="list-group-item list-group-item-action notification-head">
+                    <span class="d-flex align-items-center">
+                    <span class="text-sm btn btn-link p-0" data-behavior='notification-readall'>全部標示已讀</span>
+                    <span class="text-sm"></span>
+                    </span>
+                  </div>
                     <!-- list item-->
 <!--                     <div class="list-group-item list-group-item-action">
                        <div class="media">
@@ -58,6 +64,11 @@
                           <span class="badge badge-danger ml-auto">14</span>
                        </span>
                     </div> -->
+                  <div class="list-group-item list-group-item-action">
+                    <span class="d-flex align-items-center">
+                    <%= link_to '所有通知' , notifications_path, class: 'text-sm' %>
+                    </span>
+                  </div>
                  </div>
                  <!-- END list group-->
               </div>

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -1,0 +1,14 @@
+<aside class="aside-container">
+  <%= render partial: "layouts/sidebar" %>
+</aside>
+<section>
+  <div class="section-container">
+    <div class="content-wrapper">
+      
+        <h1>所有通知</h1>
+        <%@notifications.each do  |notification| %>
+        <%=render partial: "notifications/#{notification.notifiable_type.underscore.pluralize}/#{notification.action}", locals: {notification: notification} %>
+        <%end%>
+
+  </div>
+</section>

--- a/app/views/notifications/index.json.jbuilder
+++ b/app/views/notifications/index.json.jbuilder
@@ -1,6 +1,6 @@
-json.array! @notifications do |notification|
+json.array! @notifications.limit(10) do |notification|
   json.id notification.id
-  json.unread !notification.read_at?
+  json.unchecked !notification.checked_at?
   json.template render partial: "notifications/#{notification.notifiable_type.underscore.pluralize}/#{notification.action}", locals: {notification: notification}, formats: [:html]
 
 end

--- a/app/views/notifications/shared/_notification_item.html.erb
+++ b/app/views/notifications/shared/_notification_item.html.erb
@@ -1,4 +1,4 @@
-<div class="list-group-item list-group-item-action <%='bg-gray-light'  if !notification.read_at %>">
+<div class="list-group-item list-group-item-action <%='unread-notification'  if !notification.read_at %>">
   <%= link_to invitation_path(notification.notifiable.invitation), id: notification.id do %>
   <div class="media">
     <div class="align-self-start mr-2">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,11 @@ Rails.application.routes.draw do
 
   resources :notifications do
     collection do
-      post :mark_as_read
+      post :mark_as_checked_all
+      post :mark_as_read_all
+    end
+    member do
+      post :mark_as_read      
     end
   end
   resources :invitations, only: [:index, :show] do

--- a/db/migrate/20180326055613_add_check_at_in_notifications.rb
+++ b/db/migrate/20180326055613_add_check_at_in_notifications.rb
@@ -1,0 +1,5 @@
+class AddCheckAtInNotifications < ActiveRecord::Migration[5.2]
+  def change
+    add_column :notifications, :checked_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,6 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
 ActiveRecord::Schema.define(version: 2018_03_25_081216) do
 
   # These are extensions that must be enabled in order to support this database

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_03_25_081216) do
+ActiveRecord::Schema.define(version: 2018_03_26_055613) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -87,6 +87,7 @@ ActiveRecord::Schema.define(version: 2018_03_25_081216) do
     t.string "notifiable_type"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "checked_at"
   end
 
   create_table "reviews", force: :cascade do |t|


### PR DESCRIPTION
# Why
- navbar只載入十筆
- 將狀態分為 checked 和 read，跟臉書一樣
- 可以有read_all 功能，也可以瀏覽全部的通知
<img width="452" alt="2018-03-26 4 48 20" src="https://user-images.githubusercontent.com/15953545/37896058-8f3d6e76-3115-11e8-8b24-9ec834364073.png">
<img width="1039" alt="2018-03-26 4 48 31" src="https://user-images.githubusercontent.com/15953545/37896065-91b59890-3115-11e8-8a7d-d11c3a503752.png">

# What
原本notification#mark_as_read 在鈴鐺點後就全部標記已讀，但想要做到兩階段的已讀：
1. 點了鈴鐺，確定收到通知
2. 點了連結，確定已讀
跟臉書很像
- 新增checked_at column，確認通知的時間
- 原本read_at 就是點入該則通知才會被寫入
- 在notification.list 上下加了 全部標示已讀 和 查看所有通知

cc. @Cronobow  @eggyy1224   

