### PR TITLE
增加使用者平均rating的欄位

### DIFF
--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -2,6 +2,7 @@ class Review < ApplicationRecord
   validates :reviewer_id, uniqueness: { scope: [:reviewee_id, :instance_id] }
   validate :rating_validator
   after_commit :create_notifications
+  after_commit :update_user_rating_count!
   belongs_to :instance
   belongs_to :reviewer, class_name: "User"
   belongs_to :reviewee, class_name: "User"
@@ -32,6 +33,11 @@ class Review < ApplicationRecord
   def create_notifications
     if self.submit
       Notification.create(recipient: recipient, actor: actor, action: 'left_review', notifiable: self)
+    end
+  end
+  def update_user_rating_count!
+    if self.submit
+      self.reviewee.set_average_rating_count!
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -178,17 +178,16 @@ class User < ApplicationRecord
     self.followings.include?(other_user)
   end
 
-  def average_rating
-    #所有星星/ 所有評論數
-    total_rating = reviews.submited.inject(0){|sum,review|
-        sum + review.rating
-    }
+  def set_average_rating_count!
+    total_rating = reviews.submited.inject(0){|sum,review|sum + review.rating}
     if(reviews.submited.count > 0)
-      (total_rating.to_f / reviews.submited.count.to_f).round(1)
+      self.average_rating_count = (total_rating.to_f / reviews.submited.count.to_f).round(1)
     else
-      return 0
+      self.average_rating_count = 0
     end
+    self.save
   end
+
 
 
   def self.from_omniauth(auth)
@@ -200,5 +199,6 @@ class User < ApplicationRecord
       user.password = Devise.friendly_token[0,20]
     end
   end
+
 
 end

--- a/app/views/shared/_user_rating.html.erb
+++ b/app/views/shared/_user_rating.html.erb
@@ -1,7 +1,7 @@
 <div class="col-12 col-sm-6 mb-3 mb-sm-0 rating">
-  <span class="rating-num"><%=user.average_rating%></span>
+  <span class="rating-num"><%=user.average_rating_count%></span>
   <div class="rating-stars">
-    <%= print_rating_stars user.average_rating.round.to_i %>
+    <%= print_rating_stars user.average_rating_count.round.to_i %>
   </div>
   <div class="rating-users">
     <i class="icon-user"></i> 共有<%=rating_count.sum%>則評價

--- a/db/migrate/20180329075609_average_rating_count_to_user.rb
+++ b/db/migrate/20180329075609_average_rating_count_to_user.rb
@@ -1,0 +1,5 @@
+class AverageRatingCountToUser < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :average_rating_count, :float, default: 0, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_03_28_074123) do
+ActiveRecord::Schema.define(version: 2018_03_29_075609) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -162,6 +162,7 @@ ActiveRecord::Schema.define(version: 2018_03_28_074123) do
     t.integer "followings_count", default: 0
     t.string "provider"
     t.string "uid"
+    t.float "average_rating_count", default: 0.0, null: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -112,5 +112,12 @@ namespace :dev do
     system 'rails dev:fake_mission_tag'
     system 'rails dev:fake_followships'
   end
+  task reset_average_rating: :environment do 
+    User.all.each do |user|
+      user.set_average_rating_count!
+      puts "#{user.name} : #{user.average_rating_count}"
+    end
+  end
+
 
 end


### PR DESCRIPTION
# Why
- 使用者的平均rating可以直接查詢  User.average_rating_count 欄位
- 方便以後直接用rating排序User

# What
- 記得`db:migrate`
- 可以下`dev:reset_average_rating `可以把所有的user average_rating_count 重算一次

cc @Cronobow  @eggyy1224 