### PR TITLE
Recruit board bug fix

### DIFF
--- a/app/controllers/instances_controller.rb
+++ b/app/controllers/instances_controller.rb
@@ -96,6 +96,10 @@ class InstancesController < ApplicationController
     if @instance.state == 'teaming'
       flash[:notice] = '放棄組隊！'
       @instance.cancel!
+      # binding.pry
+      recruit_board = RecruitBoard.find_by(user_id: current_user.id, instance_id: @instance.id)
+      # 如果這個任務有對應到招募的話便把招募刪除
+      recruit_board.delete if recruit_board
       redirect_to instance_path(@instance)
     else
       flash[:alert] = "存取禁止"

--- a/app/controllers/recruit_boards_controller.rb
+++ b/app/controllers/recruit_boards_controller.rb
@@ -6,11 +6,16 @@ class RecruitBoardsController < ApplicationController
   end
 
   def create
-    recruit_board = current_user.recruit_boards.build(user_id: current_user.id, instance_id: params[:instance_id])
-    # binding.pry
-    recruit_board.save
-    flash[:notice] = "成功發動本次招募"
-    redirect_back(fallback_location: root_path)
+    id_instance = params[:instance_id].to_i
+    unless current_user.recruit_board_repeat?(id_instance)
+      recruit_board = current_user.recruit_boards.build(user_id: current_user.id, instance_id: params[:instance_id])
+      recruit_board.save
+      flash[:notice] = "成功發動本次招募"
+      redirect_back(fallback_location: root_path)
+    else
+      flash[:alert] = "本任務招募中"
+      redirect_back(fallback_location: root_path)
+    end
   end
 
   def destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -311,4 +311,9 @@ class User < ApplicationRecord
     self.description.blank? || 
     self.location.blank? 
   end
+
+  def recruit_board_repeat?(id_instance)
+    # 如果在recruit_boards裡的instance_id重複的話回傳true
+    self.recruit_boards.map(&:instance_id).include?(id_instance)
+  end
 end

--- a/app/views/instances/state/_teaming.html.erb
+++ b/app/views/instances/state/_teaming.html.erb
@@ -14,12 +14,18 @@
 
     <div class="row mb-4">
       <div class="col-12 d-flex justify-content-between">
-        <h4>尋找想要合作的探員</h4>
+        <% unless current_user.recruit_board_repeat?(@instance.id) %>
+          <h4>尋找想要合作的探員</h4>
+        <% else %>
+          <h4>尋找想要合作的探員(本任務已在招募看板上)</h4>
+        <% end %>
         <span class="btn bg-inverse-light btn-sm btn-oval">你還可發送 <span class="font-weight-bold" id="remaining_invitations"><%=@remaining_invitations_count%></span> 張邀請</span>
       </div>
-      <div class="col-12">
-        不想慢慢邀請？你還可以選擇： <%= link_to '發動緊急招募', recruit_boards_path(instance_id: params[:id]), method: :post, class: 'btn btn-sm btn-primary btn-oval ml-1 px-2 py-1' if @instance.state == "teaming" %><span class="ml-2 fa fa-question-circle  " title="" data-container="body" data-trigger='hover' data-toggle="popover" data-placement="top" data-content="緊急招募會在本局右上角的緊急招募看板出現該任務。如有任何探員願意參加，則任務立即啟動，並不需要透過邀請函同意。"> </span>
-      </div>
+      <% unless current_user.recruit_board_repeat?(@instance.id) %>
+        <div class="col-12">
+          不想慢慢邀請？你還可以選擇： <%= link_to '發動緊急招募', recruit_boards_path(instance_id: params[:id]), method: :post, class: 'btn btn-sm btn-primary btn-oval ml-1 px-2 py-1' if @instance.state == "teaming" %><span class="ml-2 fa fa-question-circle  " title="" data-container="body" data-trigger='hover' data-toggle="popover" data-placement="top" data-content="緊急招募會在本局右上角的緊急招募看板出現該任務。如有任何探員願意參加，則任務立即啟動，並不需要透過邀請函同意。"> </span>
+        </div>
+      <% end %>
     </div>
 
     <%= render( partial: 'shared/filterrific_user_form' ) %>

--- a/test/fixtures/instances.yml
+++ b/test/fixtures/instances.yml
@@ -27,5 +27,9 @@ instance_recruit:
   mission: mission7
   state: teaming
 
+instance_recruit2:
+  mission: mission7
+  state: teaming
+
 
 

--- a/test/integration/recruit_detective_test.rb
+++ b/test/integration/recruit_detective_test.rb
@@ -7,14 +7,19 @@ class RecruitDetectiveTest < ActionDispatch::IntegrationTest
     @user = users(:user)
     @user2 = users(:user2)
     @instance_recruit = instances(:instance_recruit)
+    @instance_recruit2 = instances(:instance_recruit2)
     @recruit_board = recruit_boards(:recruit_board1)
   end
   # 可以藉由招募的方式找隊友
   test "user can create a recruit request" do
     sign_in @user 
+    # 已發出招募訊息的任務不可以再次招募
+    assert_difference 'RecruitBoard.count', 0 do
+      post recruit_boards_path(instance_id: @instance_recruit.id)
+    end
     # 按招募的時候可以產生一個招募訊息
     assert_difference 'RecruitBoard.count', 1 do
-      post recruit_boards_path(instance_id: @instance_recruit.id)
+      post recruit_boards_path(instance_id: @instance_recruit2.id)
     end
   end
   # 不可以招募自己

--- a/test/integration/user_can_abort_instance_and_submit_instance_test.rb
+++ b/test/integration/user_can_abort_instance_and_submit_instance_test.rb
@@ -8,6 +8,7 @@ class UserCanAbortInstanceAndSubmitInstanceTest < ActionDispatch::IntegrationTes
     sign_in @user
     post challenge_mission_path(@mission2)
     @instance = Instance.last
+    @recruit_instance = instances(:instance_recruit)
   end
 
   test "user can abort mission" do
@@ -95,4 +96,10 @@ class UserCanAbortInstanceAndSubmitInstanceTest < ActionDispatch::IntegrationTes
     assert_equal 'cancel', instance.state
   end
 
+  # 取消有緊急招募的任務會把招募刪除
+  test "cancel recruit_board_instance will destroy recruit board" do
+    assert_difference 'RecruitBoard.count', -1 do
+      post cancel_instance_path(@recruit_instance)
+    end
+  end
 end


### PR DESCRIPTION
1. 修復重複招募錯誤，後端前端皆有修改。
2. 取消有招募的任務時會同時刪除招募訊息。
3. 加入相關測試。

@Cronobow @spreered 