### PR TITLE
修正邀請函通知問題

### DIFF
--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -1,6 +1,6 @@
 class Invitation < ApplicationRecord
   after_commit :setup_state!
-  after_commit :create_notifications if :state_changed?
+  after_commit :create_notifications, if: :state_changed?
   belongs_to :user
   belongs_to :instance
   belongs_to :invitee, class_name: "User"

--- a/app/models/invitation.rb
+++ b/app/models/invitation.rb
@@ -1,6 +1,6 @@
 class Invitation < ApplicationRecord
   after_commit :setup_state!
-  after_create_commit :create_notifications
+  after_commit :create_notifications if :state_changed?
   belongs_to :user
   belongs_to :instance
   belongs_to :invitee, class_name: "User"


### PR DESCRIPTION
#Why 
本來邀請函通的知產生寫在`after_create_commit :create_notifications` 這個callback裡面
但是如果state切換成accept  cancel  decline，就沒辦法觸發
如果只用after_commit的話，就是所有更新都觸發。

這邊改用Dirty objects，也就只監視某一個attribute是否有更動
`after_commit :create_notifications, if: :state_changed?`
這樣就只會針對該欄位更動修改
相關資料請查看
https://stackoverflow.com/questions/24314584/run-a-callback-only-if-an-attribute-has-changed-in-rails
https://ihower.tw/rails/activerecord-others.html#sec2

@Cronobow @eggyy1224 